### PR TITLE
[Feat] apple login 구현

### DIFF
--- a/src/main/java/com/letter/cookies/controller/MemberController.java
+++ b/src/main/java/com/letter/cookies/controller/MemberController.java
@@ -1,15 +1,14 @@
 package com.letter.cookies.controller;
 
+import com.letter.cookies.dto.member.request.LoginRequest;
 import com.letter.cookies.dto.member.request.TempLoginRequest;
+import com.letter.cookies.dto.member.response.MemberInfoResponse;
 import com.letter.cookies.dto.member.response.TempLoginResponse;
 import com.letter.cookies.dto.response.CustomResponse;
 import com.letter.cookies.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -25,5 +24,17 @@ public class MemberController {
     public ResponseEntity<CustomResponse> createUser(@RequestBody @Valid TempLoginRequest tempLoginRequest){
         TempLoginResponse tempLoginResponse = memberService.createMember(tempLoginRequest);
         return new CustomResponse<>(tempLoginResponse, SUCCESS).toResponseEntity();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<CustomResponse> login(@RequestBody @Valid LoginRequest loginRequest) {
+        MemberInfoResponse memberInfoResponse = memberService.login(loginRequest);
+        return new CustomResponse<>(memberInfoResponse, SUCCESS).toResponseEntity();
+    }
+
+    @GetMapping
+    public ResponseEntity<CustomResponse> getMemberInfo(@RequestHeader(value = "identifier") String identifier) {
+        MemberInfoResponse memberInfoResponse = memberService.getMemberInfo(identifier);
+        return new CustomResponse<>(memberInfoResponse, SUCCESS).toResponseEntity();
     }
 }

--- a/src/main/java/com/letter/cookies/domain/base/Member/Member.java
+++ b/src/main/java/com/letter/cookies/domain/base/Member/Member.java
@@ -27,12 +27,23 @@ public class Member extends BaseEntity {
 
     private String memberPassword;
 
+    private String memberEmail;
+
+    private String identifier;
+
     private Long cookie;
 
     @Builder
-    public Member(String memberName, String memberPassword){
+    public Member(String memberName, String memberPassword, String memberEmail, String identifier, Long cookie){
         this.memberName = memberName;
         this.memberPassword = memberPassword;
+        this.memberEmail = memberEmail;
+        this.identifier = identifier;
+        this.cookie = (cookie == null) ? 0 : cookie;
+    }
+
+    public void update(String memberName) {
+        this.memberName = memberName;
     }
 
     public void cookieSpent() {

--- a/src/main/java/com/letter/cookies/domain/base/Member/MemberRepository.java
+++ b/src/main/java/com/letter/cookies/domain/base/Member/MemberRepository.java
@@ -8,4 +8,7 @@ import java.util.UUID;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, UUID> {
+
+    Member findByIdentifier(String identifier);
+
 }

--- a/src/main/java/com/letter/cookies/dto/member/request/LoginRequest.java
+++ b/src/main/java/com/letter/cookies/dto/member/request/LoginRequest.java
@@ -1,0 +1,38 @@
+package com.letter.cookies.dto.member.request;
+
+import com.letter.cookies.domain.base.Member.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+
+    @NotBlank
+    @Size(min=3, max=10)
+    private String memberName;
+
+    @NotBlank
+    @Email
+    private String memberEmail;
+
+    private String memberPassword;
+
+    @NotBlank
+    private String identifier;
+
+    public Member toEntity(Long cookie){
+        return Member.builder()
+                .memberName(memberName)
+                .memberPassword(memberPassword)
+                .memberEmail(memberEmail)
+                .identifier(identifier)
+                .cookie(cookie)
+                .build();
+    }
+
+}

--- a/src/main/java/com/letter/cookies/dto/member/request/LoginRequest.java
+++ b/src/main/java/com/letter/cookies/dto/member/request/LoginRequest.java
@@ -20,7 +20,6 @@ public class LoginRequest {
     @Email
     private String memberEmail;
 
-    private String memberPassword;
 
     @NotBlank
     private String identifier;
@@ -28,7 +27,6 @@ public class LoginRequest {
     public Member toEntity(Long cookie){
         return Member.builder()
                 .memberName(memberName)
-                .memberPassword(memberPassword)
                 .memberEmail(memberEmail)
                 .identifier(identifier)
                 .cookie(cookie)

--- a/src/main/java/com/letter/cookies/dto/member/response/MemberInfoResponse.java
+++ b/src/main/java/com/letter/cookies/dto/member/response/MemberInfoResponse.java
@@ -1,0 +1,19 @@
+package com.letter.cookies.dto.member.response;
+
+import com.letter.cookies.domain.base.Member.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberInfoResponse {
+
+    private String memberName;
+    private Long cookie;
+
+    public MemberInfoResponse(Member entity) {
+        this.memberName = entity.getMemberName();
+        this.cookie = entity.getCookie();
+    }
+
+}

--- a/src/main/java/com/letter/cookies/service/MemberService.java
+++ b/src/main/java/com/letter/cookies/service/MemberService.java
@@ -2,21 +2,42 @@ package com.letter.cookies.service;
 
 import com.letter.cookies.domain.base.Member.Member;
 import com.letter.cookies.domain.base.Member.MemberRepository;
-import com.letter.cookies.domain.base.ReadLetter.ReadLetterRepository;
+import com.letter.cookies.dto.member.request.LoginRequest;
 import com.letter.cookies.dto.member.request.TempLoginRequest;
+import com.letter.cookies.dto.member.response.MemberInfoResponse;
 import com.letter.cookies.dto.member.response.TempLoginResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
-    private final ReadLetterRepository readLetterRepository;
 
     public TempLoginResponse createMember(TempLoginRequest tempLoginRequest) {
         Member member = memberRepository
                 .save(tempLoginRequest.toEntity(tempLoginRequest));
         return TempLoginResponse.builder().memberId(member.getMemberId().toString()).build();
+    }
+
+    @Transactional
+    public MemberInfoResponse login(LoginRequest loginRequest) {
+        Member member = memberRepository.findByIdentifier(loginRequest.getIdentifier());
+        if (member == null) { // 신규유저
+            member = loginRequest.toEntity(10L);
+            memberRepository.save(member);
+        } else { // 기존유저
+            member.update(loginRequest.getMemberName());
+        }
+        return new MemberInfoResponse(member);
+    }
+
+    public MemberInfoResponse getMemberInfo(String identifier) {
+        Member member = memberRepository.findByIdentifier(identifier);
+        return new MemberInfoResponse(member);
     }
 }


### PR DESCRIPTION
* user table에 identifier와 member_email 컬럼 추가해야함
* 신규유저 가입시 쿠키 10개 세팅 후 데이터베이스에 저장, 기존유저의 경우 닉네임만 업데이트
* 로그인 후에는 멤버의 이름과 쿠키 개수 반환 (클라이언트쪽과 논의 후 변경될 수 있음)
* 로그인 이후 멤버 관련 요청시에는 Request Header에 `identifier`를 담아서 보내도록